### PR TITLE
feat: add world placeholder to level formula

### DIFF
--- a/src/main/java/me/often/aureliummobs/listeners/MobSpawn.java
+++ b/src/main/java/me/often/aureliummobs/listeners/MobSpawn.java
@@ -110,6 +110,7 @@ public class MobSpawn implements Listener {
                 int level;
                 if (players.size() == 0 || sumlevel == 0) {
                     String lformula = MessageUtils.setPlaceholders(null, plugin.getConfigString("settings.default-mob-level-formula")
+                            .replace("{world}", monster.getLocation().getWorld().getName())
                             .replace("{distance}", Double.toString(distance))
                             .replace("{sumlevel_global}", Integer.toString(Main.getInstance().getGlobalLevel()))
                             .replace("{location_x}", Double.toString(monster.getLocation().getX()))
@@ -120,6 +121,7 @@ public class MobSpawn implements Listener {
                 }
                 else {
                     String lformula = MessageUtils.setPlaceholders(null, plugin.getConfigString("settings.mob-level-formula")
+                            .replace("{world}", monster.getLocation().getWorld().getName())
                             .replace("{highestlvl}", Integer.toString(maxlevel))
                             .replace("{lowestlvl}", Integer.toString(minlevel))
                             .replace("{sumlevel}", Integer.toString(sumlevel))

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,6 +34,7 @@ settings:
   # ANY PLACEHOLDERAPI PLACEHOLDER
   player-level-formula: "{sumall}"
   # Available variables:
+  # {world} - name of world, can be used in changeoutput placeholder
   # {sumlevel} - summ level of all players in the check-radius
   # {playercount} - count of players in check-radius
   # {highestlvl} - highest of player levels in check-radius
@@ -46,6 +47,7 @@ settings:
   # ANY PLAYER-UNRELATED PLACEHOLDERAPI PLACEHOLDER
   mob-level-formula: "{sumlevel}/{playercount}"
   # Available variables:
+  # {world} - name of world, can be used in changeoutput placeholder
   # {distance} - distance from world spawnpoint
   # {sumlevel_global} - summ level of all players online
   # {location_x} - X coordinate of the mob

--- a/src/main/resources/config_ru.yml
+++ b/src/main/resources/config_ru.yml
@@ -34,6 +34,7 @@ settings:
   # ANY PLACEHOLDERAPI PLACEHOLDER
   player-level-formula: "{sumall}" #ALL FORMULAS SUPPORT PLACEHOLDERAPI PLACEHOLDERS!
   # Available variables:
+  # {world} - name of world, can be used in changeoutput placeholder
   # {sumlevel} - summ level of all players in the check-radius
   # {playercount} - count of players in check-radius
   # {highestlvl} - highest of player levels in check-radius
@@ -45,6 +46,7 @@ settings:
   # ANY PLAYER-UNRELATED PLACEHOLDERAPI PLACEHOLDER
   mob-level-formula: "{sumlevel}/{playercount}" #ALL FORMULAS SUPPORT PLACEHOLDERAPI PLACEHOLDERS!
   # Available variables:
+  # {world} - name of world, can be used in changeoutput placeholder
   # {distance} - distance from world spawnpoint
   # {sumlevel_global} - summ level of all players online
   # {location_x} - X coordinate of the mob


### PR DESCRIPTION
Can be used in the changeoutput placeholder for example:

```yml
  mob-level-formula: "({distance}*0.01)+%changeoutput_equals_input:{world}_matcher:world_nether_ifmatch:100_else:0%+%changeoutput_equals_input:{world}_matcher:world_the_end_ifmatch:300_else:0%"
```

Adds extra levels for nether and end worlds.