### PR TITLE
Add Support to ignore MythicMobs-Entities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://maven.enginehub.org/repo/")
     maven("https://repo.aikar.co/content/groups/aikar/")
-    maven("https://repo.helpch.at/releases/")
+    maven("https://mvn.lumine.io/repository/maven-public/")
 }
 
 dependencies {
@@ -31,6 +31,7 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.7-SNAPSHOT")
+    compileOnly("io.lumine:Mythic-Dist:5.6.1")
 }
 
 tasks.withType<ShadowJar> {

--- a/src/main/java/dev/aurelium/auramobs/AuraMobs.java
+++ b/src/main/java/dev/aurelium/auramobs/AuraMobs.java
@@ -48,6 +48,8 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
     private List<String> enabledWorlds;
     private boolean worldWhitelist;
     private boolean placeholderAPIEnabled;
+    private boolean mythicMobsEnabled;
+    private boolean ignoreMythicMobs;
 
     @Override
     public void onLoad() {
@@ -83,6 +85,7 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
         namesEnabled = optionBoolean("custom_name.enabled");
         scaleManager = new ScaleManager(this);
         scaleManager.loadConfiguration();
+        ignoreMythicMobs = optionBoolean("custom_name.ignore_mythic_mobs");
 
         this.getServer().getPluginManager().registerEvents(new MobSpawn(this), this);
         this.getServer().getPluginManager().registerEvents(new EntityXpGainListener(this), this);
@@ -107,6 +110,7 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
         formatter = new Formatter(optionInt("custom_name.health_rounding_places"));
         // Check for PlaceholderAPI
         placeholderAPIEnabled = getServer().getPluginManager().isPluginEnabled("PlaceholderAPI");
+        mythicMobsEnabled = getServer().getPluginManager().isPluginEnabled("MythicMobs");
     }
 
     @Override
@@ -224,6 +228,10 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
         return worldWhitelist;
     }
 
+    public boolean ignoreMythicMobs() {
+        return ignoreMythicMobs;
+    }
+
     public WorldGuardHook getWorldGuard() {
         return worldGuard;
     }
@@ -234,6 +242,10 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
 
     public boolean isPlaceholderAPIEnabled() {
         return placeholderAPIEnabled;
+    }
+
+    public boolean isMythicMobsEnabled() {
+        return mythicMobsEnabled;
     }
 
     // Message and config convenience methods

--- a/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
@@ -4,6 +4,7 @@ import dev.aurelium.auramobs.AuraMobs;
 import dev.aurelium.auramobs.api.WorldGuardHook;
 import dev.aurelium.auramobs.entities.AureliumMob;
 import dev.aurelium.auramobs.util.MessageUtils;
+import io.lumine.mythic.core.constants.MobKeys;
 import net.objecthunter.exp4j.ExpressionBuilder;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -15,6 +16,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.metadata.MetadataValue;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -108,6 +110,9 @@ public class MobSpawn implements Listener {
                 if (entity.isDead() || !entity.isValid()) {
                     return;
                 }
+
+                if (plugin.isMythicMobsEnabled() && entity.getPersistentDataContainer().has(MobKeys.TYPE, PersistentDataType.STRING) && plugin.ignoreMythicMobs()) return;
+
                 int sumlevel = 0;
                 int maxlevel = Integer.MIN_VALUE;
                 int minlevel = Integer.MAX_VALUE;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,6 +40,7 @@ custom_name:
   display_by_range: true
   display_range: 5
   allow_override: true
+  ignore_mythic_mobs: true
 skills_xp:
   enabled: true
   default_formula: '{source_xp} * (1 + {mob_level} / 100)'


### PR DESCRIPTION
Added an option to allow AuraMobs to ignore MythicMobs-Entities since the custom_name option does not apply to client side nametags and therefore needs special treatment.

For more, GitHub Copilot is here to explain the changes lol (crazy feature, had to test it once):
This pull request introduces several changes to the `AuraMobs` plugin to add support for MythicMobs integration and configuration. The most important changes include adding new configuration options and methods to handle MythicMobs, as well as updating the `MobSpawn` listener to respect these new settings.

### MythicMobs Integration:

* [`src/main/java/dev/aurelium/auramobs/AuraMobs.java`](diffhunk://#diff-e6668d0d09083a6421d07113b1301b4e16d7e2914b15dfbda656afb6ae2db67aR51-R52): Added `mythicMobsEnabled` and `ignoreMythicMobs` fields, and updated `onEnable` method to initialize these fields. Added `ignoreMythicMobs()` and `isMythicMobsEnabled()` methods for accessing these fields. [[1]](diffhunk://#diff-e6668d0d09083a6421d07113b1301b4e16d7e2914b15dfbda656afb6ae2db67aR51-R52) [[2]](diffhunk://#diff-e6668d0d09083a6421d07113b1301b4e16d7e2914b15dfbda656afb6ae2db67aR88) [[3]](diffhunk://#diff-e6668d0d09083a6421d07113b1301b4e16d7e2914b15dfbda656afb6ae2db67aR113) [[4]](diffhunk://#diff-e6668d0d09083a6421d07113b1301b4e16d7e2914b15dfbda656afb6ae2db67aR231-R234) [[5]](diffhunk://#diff-e6668d0d09083a6421d07113b1301b4e16d7e2914b15dfbda656afb6ae2db67aR247-R250)

### MobSpawn Listener Update:

* [`src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java`](diffhunk://#diff-5056d277a4e9d878ece749fa9dc8ab6dac7303855be99486ddc5ddb4cbabbeafR7): Imported `MobKeys` and `PersistentDataType` to check for MythicMobs entities. Updated the `run` method to skip processing if the entity is a MythicMob and `ignoreMythicMobs` is enabled. [[1]](diffhunk://#diff-5056d277a4e9d878ece749fa9dc8ab6dac7303855be99486ddc5ddb4cbabbeafR7) [[2]](diffhunk://#diff-5056d277a4e9d878ece749fa9dc8ab6dac7303855be99486ddc5ddb4cbabbeafR19) [[3]](diffhunk://#diff-5056d277a4e9d878ece749fa9dc8ab6dac7303855be99486ddc5ddb4cbabbeafR113-R115)

### Configuration Changes:

* [`src/main/resources/config.yml`](diffhunk://#diff-58cdd3d308ccba6c594e040ff9c065bb11eeb6e30f35ba87694ea45d5ae6096cR43): Added `ignore_mythic_mobs` configuration option under `custom_name` section.