### PR TITLE
Add MM to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ depend:
 softdepend:
   - PlaceholderAPI
   - WorldGuard
+  - MythicMobs
 permissions:
   auramobs.reload:
     default: op


### PR DESCRIPTION
Should resolve random issues when the MM detection doesn't actually work because AuraMobs thinks MM isn't enabled due to incorrect load order.