### PR TITLE
Custom summon command, accurate damage scaling for creeper explosions and arrows from skeletons, movement speed property & custom exp4j functions

### DIFF
--- a/src/main/java/dev/aurelium/auramobs/AuraMobs.java
+++ b/src/main/java/dev/aurelium/auramobs/AuraMobs.java
@@ -6,6 +6,7 @@ import com.archyx.polyglot.PolyglotProvider;
 import com.archyx.polyglot.config.PolyglotConfig;
 import com.archyx.polyglot.config.PolyglotConfigBuilder;
 import com.archyx.polyglot.lang.MessageKey;
+import com.google.common.collect.ImmutableList;
 import dev.aurelium.auramobs.api.AuraMobsAPI;
 import dev.aurelium.auramobs.api.WorldGuardHook;
 import dev.aurelium.auramobs.commands.AuraMobsCommand;
@@ -27,10 +28,7 @@ import org.bukkit.entity.*;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public class AuraMobs extends JavaPlugin implements PolyglotProvider {
 
@@ -129,6 +127,11 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
     public void registerCommands() {
         PaperCommandManager manager = new PaperCommandManager(this);
         manager.registerCommand(new AuraMobsCommand(this));
+        manager.getCommandCompletions().registerCompletion("entitytypes", c -> Arrays.stream(EntityType.values())
+                .filter(type -> type.isSpawnable() && type.isAlive())
+                .map(type -> type.name().toLowerCase(Locale.ROOT))
+                .toList());
+        manager.getCommandCompletions().registerCompletion("level", c -> ImmutableList.of("<level>"));
     }
 
     public AuraSkillsApi getAuraSkills() {

--- a/src/main/java/dev/aurelium/auramobs/AuraMobs.java
+++ b/src/main/java/dev/aurelium/auramobs/AuraMobs.java
@@ -34,10 +34,13 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
 
     private static final int bstatsId = 22266;
     private NamespacedKey mobKey;
+    private NamespacedKey levelKey;
+    private NamespacedKey summonKey;
     private WorldGuardHook worldGuard;
     private AuraSkillsApi auraSkills;
     private double maxHealth;
     private double maxDamage;
+    private double maxSpeed;
     private boolean namesEnabled;
     private int globalLevel;
     private Formatter formatter;
@@ -83,6 +86,8 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
         }
         language = Locale.forLanguageTag(optionString("language").replace("_", "-"));
         mobKey = new NamespacedKey(this, "isAureliumMob");
+        levelKey = new NamespacedKey(this, "auramobs_level");
+        summonKey = new NamespacedKey(this, "auramobs_custom_summoned");
         namesEnabled = optionBoolean("custom_name.enabled");
         scaleManager = new ScaleManager(this);
         scaleManager.loadConfiguration();
@@ -107,6 +112,7 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
         loadWorlds();
         maxHealth = Bukkit.spigot().getConfig().getDouble("settings.attribute.maxHealth.max");
         maxDamage = Bukkit.spigot().getConfig().getDouble("settings.attribute.attackDamage.max");
+        maxSpeed = Bukkit.spigot().getConfig().getDouble("settings.attribute.movementSpeed.max");
 
         formatter = new Formatter(optionInt("custom_name.health_rounding_places"));
         // Check for PlaceholderAPI
@@ -160,6 +166,10 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
 
     public double getMaxDamage() {
         return maxDamage;
+    }
+
+    public double getMaxSpeed() {
+        return maxSpeed;
     }
 
     public int getSumLevel(Player player) {
@@ -245,6 +255,14 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
 
     public NamespacedKey getMobKey() {
         return mobKey;
+    }
+
+    public NamespacedKey getLevelKey() {
+        return levelKey;
+    }
+
+    public NamespacedKey getSummonKey() {
+        return summonKey;
     }
 
     public boolean isPlaceholderAPIEnabled() {

--- a/src/main/java/dev/aurelium/auramobs/AuraMobs.java
+++ b/src/main/java/dev/aurelium/auramobs/AuraMobs.java
@@ -14,6 +14,7 @@ import dev.aurelium.auramobs.config.ConfigManager;
 import dev.aurelium.auramobs.config.OptionKey;
 import dev.aurelium.auramobs.config.OptionValue;
 import dev.aurelium.auramobs.listeners.*;
+import dev.aurelium.auramobs.util.CustomFunctions;
 import dev.aurelium.auramobs.util.Formatter;
 import dev.aurelium.auramobs.entities.ScaleManager;
 import dev.aurelium.auraskills.api.AuraSkillsApi;
@@ -21,6 +22,7 @@ import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.api.skill.Skills;
 import dev.aurelium.auraskills.api.user.SkillsUser;
 import net.objecthunter.exp4j.ExpressionBuilder;
+import net.objecthunter.exp4j.function.Function;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -216,7 +218,9 @@ public class AuraMobs extends JavaPlugin implements PolyglotProvider {
             formula = formula.replace(replace, Integer.toString(user.getSkillLevel(skill)));
         }
 
-        return (int) Math.round(new ExpressionBuilder(formula).build().evaluate());
+        ExpressionBuilder builder = new ExpressionBuilder(formula);
+        for (Function func : CustomFunctions.getCustomFunctions()) builder.function(func);
+        return (int) Math.round(builder.build().evaluate());
     }
 
     public boolean isAuraMob(LivingEntity m) {

--- a/src/main/java/dev/aurelium/auramobs/commands/AuraMobsCommand.java
+++ b/src/main/java/dev/aurelium/auramobs/commands/AuraMobsCommand.java
@@ -59,11 +59,9 @@ public class AuraMobsCommand extends BaseCommand {
             return;
         }
 
-        NamespacedKey summonKey = new NamespacedKey(plugin, "auramobs_custom_summoned");
-
         LivingEntity entity = (LivingEntity) player.getWorld().spawn(player.getLocation(), type.getEntityClass(), ent -> {
             if (ent instanceof LivingEntity living) {
-                living.getPersistentDataContainer().set(summonKey, PersistentDataType.BYTE, (byte) 1);
+                living.getPersistentDataContainer().set(plugin.getSummonKey(), PersistentDataType.BYTE, (byte) 1);
             }
         });
         new AureliumMob(entity, level, plugin);

--- a/src/main/java/dev/aurelium/auramobs/commands/AuraMobsCommand.java
+++ b/src/main/java/dev/aurelium/auramobs/commands/AuraMobsCommand.java
@@ -5,7 +5,6 @@ import co.aikar.commands.annotation.*;
 import dev.aurelium.auramobs.AuraMobs;
 import dev.aurelium.auramobs.entities.AureliumMob;
 import dev.aurelium.auramobs.util.ColorUtils;
-import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -53,7 +52,7 @@ public class AuraMobsCommand extends BaseCommand {
             return;
         }
 
-        if (!type.isSpawnable() || !type.isAlive() || type.getEntityClass() == null) {
+        if (!type.isSpawnable() || !type.isAlive() || type.getEntityClass() == null || plugin.isInvalidEntity(type.getEntityClass())) {
             sender.sendMessage(ColorUtils.colorMessage(plugin.getMsg("commands.summon.failure")
                     .replace("{mob}", type.name()).replace("{level}", String.valueOf(level))));
             return;

--- a/src/main/java/dev/aurelium/auramobs/commands/AuraMobsCommand.java
+++ b/src/main/java/dev/aurelium/auramobs/commands/AuraMobsCommand.java
@@ -1,12 +1,16 @@
 package dev.aurelium.auramobs.commands;
 
 import co.aikar.commands.BaseCommand;
-import co.aikar.commands.annotation.CommandAlias;
-import co.aikar.commands.annotation.CommandPermission;
-import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.annotation.*;
 import dev.aurelium.auramobs.AuraMobs;
+import dev.aurelium.auramobs.entities.AureliumMob;
 import dev.aurelium.auramobs.util.ColorUtils;
+import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.Locale;
 
@@ -30,5 +34,42 @@ public class AuraMobsCommand extends BaseCommand {
         sender.sendMessage(ColorUtils.colorMessage(plugin.getMsg("commands.reload")));
     }
 
+    @Subcommand("summon")
+    @CommandPermission("auramobs.summon")
+    @Syntax("<type> <level>")
+    @CommandCompletion("@entitytypes @level")
+    public void onSummon(CommandSender sender, String mobType, int level) {
+
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ColorUtils.colorMessage(plugin.getMsg("commands.summon.console")));
+            return;
+        }
+
+        EntityType type;
+        try {
+            type = EntityType.valueOf(mobType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            sender.sendMessage(ColorUtils.colorMessage(plugin.getMsg("commands.summon.invalid").replace("{type}", mobType)));
+            return;
+        }
+
+        if (!type.isSpawnable() || !type.isAlive() || type.getEntityClass() == null) {
+            sender.sendMessage(ColorUtils.colorMessage(plugin.getMsg("commands.summon.failure")
+                    .replace("{mob}", type.name()).replace("{level}", String.valueOf(level))));
+            return;
+        }
+
+        NamespacedKey summonKey = new NamespacedKey(plugin, "auramobs_custom_summoned");
+
+        LivingEntity entity = (LivingEntity) player.getWorld().spawn(player.getLocation(), type.getEntityClass(), ent -> {
+            if (ent instanceof LivingEntity living) {
+                living.getPersistentDataContainer().set(summonKey, PersistentDataType.BYTE, (byte) 1);
+            }
+        });
+        new AureliumMob(entity, level, plugin);
+
+        sender.sendMessage(ColorUtils.colorMessage(plugin.getMsg("commands.summon.success")
+                .replace("{mob}", type.name()).replace("{level}", String.valueOf(level))));
+    }
 
 }

--- a/src/main/java/dev/aurelium/auramobs/entities/AureliumMob.java
+++ b/src/main/java/dev/aurelium/auramobs/entities/AureliumMob.java
@@ -2,9 +2,11 @@ package dev.aurelium.auramobs.entities;
 
 import dev.aurelium.auramobs.AuraMobs;
 import dev.aurelium.auramobs.util.ColorUtils;
+import dev.aurelium.auramobs.util.CustomFunctions;
 import dev.aurelium.auramobs.util.MessageUtils;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
+import net.objecthunter.exp4j.function.Function;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
@@ -55,9 +57,16 @@ public class AureliumMob {
                 .replace("{level}", Integer.toString(level1))
                 .replace("{distance}", Double.toString(distance))
         );
-        Expression resDamage = new ExpressionBuilder(damageFormula).build();
-        Expression resHealth = new ExpressionBuilder(healthFormula).build();
-        Expression resSpeed = new ExpressionBuilder(speedFormula).build();
+
+        ExpressionBuilder bDamage = new ExpressionBuilder(damageFormula);
+        ExpressionBuilder bHealth = new ExpressionBuilder(healthFormula);
+        ExpressionBuilder bSpeed = new ExpressionBuilder(speedFormula);
+        for (Function func : CustomFunctions.getCustomFunctions()) bDamage.function(func);
+        for (Function func : CustomFunctions.getCustomFunctions()) bHealth.function(func);
+        for (Function func : CustomFunctions.getCustomFunctions()) bSpeed.function(func);
+        Expression resDamage = bDamage.build();
+        Expression resHealth = bHealth.build();
+        Expression resSpeed = bSpeed.build();
         double damage = BigDecimal.valueOf(resDamage.evaluate()).setScale(2, RoundingMode.CEILING).doubleValue();
         double health = resHealth.evaluate();
         double speed = resSpeed.evaluate();
@@ -69,7 +78,9 @@ public class AureliumMob {
                     .replace("{level}", String.valueOf(level1))
                     .replace("{distance}", Double.toString(distance))
             );
-            Expression resMaxDamage = new ExpressionBuilder(damageMax).build();
+            ExpressionBuilder builder = new ExpressionBuilder(damageMax);
+            for (Function func : CustomFunctions.getCustomFunctions()) builder.function(func);
+            Expression resMaxDamage = builder.build();
             double maxDamage = BigDecimal.valueOf(resMaxDamage.evaluate()).setScale(2, RoundingMode.CEILING).doubleValue();
             damage = Math.min(maxDamage, damage);
         }
@@ -80,7 +91,9 @@ public class AureliumMob {
                     .replace("{level}", String.valueOf(level1))
                     .replace("{distance}", Double.toString(distance))
             );
-            Expression resMaxHealth = new ExpressionBuilder(healthMax).build();
+            ExpressionBuilder builder = new ExpressionBuilder(healthMax);
+            for (Function func : CustomFunctions.getCustomFunctions()) builder.function(func);
+            Expression resMaxHealth = builder.build();
             double maxHealth = resMaxHealth.evaluate();
             health = Math.min(maxHealth, health);
         }
@@ -91,7 +104,9 @@ public class AureliumMob {
                     .replace("{level}", String.valueOf(level1))
                     .replace("{distance}", Double.toString(distance))
             );
-            Expression resMaxSpeed = new ExpressionBuilder(speedMax).build();
+            ExpressionBuilder builder = new ExpressionBuilder(speedMax);
+            for (Function func : CustomFunctions.getCustomFunctions()) builder.function(func);
+            Expression resMaxSpeed = builder.build();
             double maxSpeed = resMaxSpeed.evaluate();
             speed = Math.min(maxSpeed, speed);
         }

--- a/src/main/java/dev/aurelium/auramobs/listeners/EntityXpGainListener.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/EntityXpGainListener.java
@@ -1,10 +1,12 @@
 package dev.aurelium.auramobs.listeners;
 
 import dev.aurelium.auramobs.AuraMobs;
+import dev.aurelium.auramobs.util.CustomFunctions;
 import dev.aurelium.auramobs.util.MessageUtils;
 import dev.aurelium.auraskills.api.event.skill.EntityXpGainEvent;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
+import net.objecthunter.exp4j.function.Function;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -40,7 +42,9 @@ public class EntityXpGainListener implements Listener {
         String defaultFormula = MessageUtils.setPlaceholders(player, plugin.optionString("skills_xp.default_formula"))
                 .replace("{source_xp}", String.valueOf(sourceXp))
                 .replace("{mob_level}", String.valueOf(mobLevel));
-        Expression formula = new ExpressionBuilder(defaultFormula).build();
+        ExpressionBuilder builder = new ExpressionBuilder(defaultFormula);
+        for (Function func : CustomFunctions.getCustomFunctions()) builder.function(func);
+        Expression formula = builder.build();
         double modifiedXp = formula.evaluate();
         event.setAmount(modifiedXp);
     }

--- a/src/main/java/dev/aurelium/auramobs/listeners/MobDamage.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/MobDamage.java
@@ -3,9 +3,11 @@ package dev.aurelium.auramobs.listeners;
 import co.aikar.commands.LogLevel;
 import dev.aurelium.auramobs.AuraMobs;
 import dev.aurelium.auramobs.util.ColorUtils;
+import dev.aurelium.auramobs.util.CustomFunctions;
 import dev.aurelium.auramobs.util.MessageUtils;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
+import net.objecthunter.exp4j.function.Function;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
@@ -134,7 +136,9 @@ public class MobDamage implements Listener {
     }
 
     private double evaluate(String expression) {
-        return new ExpressionBuilder(expression).build().evaluate();
+        ExpressionBuilder builder = new ExpressionBuilder(expression);
+        for (Function func : CustomFunctions.getCustomFunctions()) builder.function(func);
+        return builder.build().evaluate();
     }
 
 }

--- a/src/main/java/dev/aurelium/auramobs/listeners/MobDamage.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/MobDamage.java
@@ -78,7 +78,7 @@ public class MobDamage implements Listener {
         if (!(damager instanceof Creeper)) return;
         if (!plugin.isAuraMob(damager)) return;
 
-        double multiplier = plugin.optionDouble("mob_defaults.damage.explosion-multiplier");
+        double multiplier = plugin.optionDouble("mob_defaults.damage.explosion_multiplier");
         e.setDamage(scaleNonBossMobDamage(e.getFinalDamage() * multiplier, damager));
     }
 
@@ -96,7 +96,7 @@ public class MobDamage implements Listener {
             return;
         }
 
-        double multiplier = plugin.optionDouble("mob_defaults.damage.projectile-multiplier");
+        double multiplier = plugin.optionDouble("mob_defaults.damage.projectile_multiplier");
         e.setDamage(scaleNonBossMobDamage(e.getFinalDamage() * multiplier, entity));
     }
 

--- a/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
@@ -7,6 +7,7 @@ import dev.aurelium.auramobs.util.MessageUtils;
 import io.lumine.mythic.core.constants.MobKeys;
 import net.objecthunter.exp4j.ExpressionBuilder;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -16,6 +17,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.metadata.MetadataValue;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -69,6 +71,12 @@ public class MobSpawn implements Listener {
                 if (e.getEntity().getCustomName() != null) {
                     return;
                 }
+            }
+
+            NamespacedKey summonKey = new NamespacedKey(plugin, "auramobs_custom_summoned");
+            PersistentDataContainer data = entity.getPersistentDataContainer();
+            if (data.has(summonKey, PersistentDataType.BYTE)) {
+                return; // Already handled via command
             }
 
             int radius = plugin.optionInt("player_level.check_radius");

--- a/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
@@ -73,9 +73,8 @@ public class MobSpawn implements Listener {
                 }
             }
 
-            NamespacedKey summonKey = new NamespacedKey(plugin, "auramobs_custom_summoned");
             PersistentDataContainer data = entity.getPersistentDataContainer();
-            if (data.has(summonKey, PersistentDataType.BYTE)) {
+            if (data.has(plugin.getSummonKey(), PersistentDataType.BYTE)) {
                 return; // Already handled via command
             }
 

--- a/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
+++ b/src/main/java/dev/aurelium/auramobs/listeners/MobSpawn.java
@@ -3,9 +3,11 @@ package dev.aurelium.auramobs.listeners;
 import dev.aurelium.auramobs.AuraMobs;
 import dev.aurelium.auramobs.api.WorldGuardHook;
 import dev.aurelium.auramobs.entities.AureliumMob;
+import dev.aurelium.auramobs.util.CustomFunctions;
 import dev.aurelium.auramobs.util.MessageUtils;
 import io.lumine.mythic.core.constants.MobKeys;
 import net.objecthunter.exp4j.ExpressionBuilder;
+import net.objecthunter.exp4j.function.Function;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
@@ -185,7 +187,9 @@ public class MobSpawn implements Listener {
                     .replace("{random_double}", String.valueOf(random.nextDouble()))
             );
         }
-        level = (int) new ExpressionBuilder(lformula).build().evaluate();
+        ExpressionBuilder lBuilder = new ExpressionBuilder(lformula);
+        for (Function func : CustomFunctions.getCustomFunctions()) lBuilder.function(func);
+        level = (int) lBuilder.build().evaluate();
         level = Math.min(level, plugin.optionInt(prefix + "max_level"));
         return level;
     }

--- a/src/main/java/dev/aurelium/auramobs/util/CustomFunctions.java
+++ b/src/main/java/dev/aurelium/auramobs/util/CustomFunctions.java
@@ -1,0 +1,74 @@
+package dev.aurelium.auramobs.util;
+
+import net.objecthunter.exp4j.function.Function;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomFunctions {
+
+    public static List<Function> getCustomFunctions() {
+        List<Function> functions = new ArrayList<>();
+
+        // Returns a random number between min (args[0]) and max (args[1])
+        // Usage: random_between(min, max)
+        functions.add(new Function("random_between", 2) {
+            @Override
+            public double apply(double... args) {
+                return args[0] + Math.random() * (args[1] - args[0]);
+            }
+        });
+
+        // Returns a random float between 0 and 1
+        // Usage: rand()
+        functions.add(new Function("rand", 0) {
+            @Override
+            public double apply(double... args) {
+                return Math.random();
+            }
+        });
+
+        // Clamps a value between a minimum and maximum
+        // Usage: clamp(value, min, max)
+        // Example: clamp(12, 0, 10) -> returns 10
+        functions.add(new Function("clamp", 3) {
+            @Override
+            public double apply(double... args) {
+                return Math.max(args[1], Math.min(args[0], args[2]));
+            }
+        });
+
+        // Performs linear interpolation between a and b using t (0.0 to 1.0)
+        // Usage: lerp(a, b, t)
+        // Example: lerp(10, 20, 0.5) -> returns 15
+        functions.add(new Function("lerp", 3) {
+            @Override
+            public double apply(double... args) {
+                return args[0] + (args[1] - args[0]) * args[2];
+            }
+        });
+
+        // Computes the logarithm of a value with a custom base
+        // Usage: logn(base, value)
+        // Example: logn(2, 8) -> returns 3
+        functions.add(new Function("logn", 2) {
+            @Override
+            public double apply(double... args) {
+                return Math.log(args[1]) / Math.log(args[0]);
+            }
+        });
+
+        // Rounds a value to the nearest whole number
+        // Usage: round(x)
+        // Example: round(4.6) -> returns 5
+        functions.add(new Function("round", 1) {
+            @Override
+            public double apply(double... args) {
+                return Math.round(args[0]);
+            }
+        });
+
+        return functions;
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,8 +11,8 @@ mob_defaults:
   damage:
     formula: '{mob_damage} + ({mob_damage} * ({level} - 1) / 25)'
     max: ''
-    explosion-multiplier: 1.0
-    projectile-multiplier: 1.0
+    explosion_multiplier: 1.0
+    projectile_multiplier: 1.0
   health:
     formula: '{mob_health} * (1 + ({level} - 1) / 25)'
     max: ''

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,8 +11,13 @@ mob_defaults:
   damage:
     formula: '{mob_damage} + ({mob_damage} * ({level} - 1) / 25)'
     max: ''
+    explosion-multiplier: 1.0
+    projectile-multiplier: 1.0
   health:
     formula: '{mob_health} * (1 + ({level} - 1) / 25)'
+    max: ''
+  speed:
+    formula: '{mob_speed} + sqrt({level}) * 0.01'
     max: ''
 mob_level:
   formula: '{sumlevel}/{playercount}'

--- a/src/main/resources/messages/messages_de.yml
+++ b/src/main/resources/messages/messages_de.yml
@@ -1,5 +1,10 @@
 commands:
   reload: 'AuraMobs erfolgreich neu geladen!'
+  summon:
+    console: 'Dieser Befehl kann nur von Spielern ausgeführt werden!'
+    invalid: 'Ungültiger Mob-Typ: {type}'
+    failure: 'Fehler beim Beschwören eines LvL {level} {mob}!'
+    success: 'Erfolgreich einen LvL {level} {mob} beschworen!'
 mobs:
   blaze: Lohe
   cave_spider: Höhlenspinne
@@ -40,4 +45,4 @@ mobs:
   ender_dragon: Enderdrache
   wither: Wither
   elder_guardian: Großwächter
-file_version: 1
+file_version: 2

--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -1,5 +1,10 @@
 commands:
   reload: 'AuraMobs successfully reloaded!'
+  summon:
+    console: 'This subcommand may only be executed by players!'
+    invalid: 'Invalid mob type: {type}'
+    failure: 'Failed to summon a lvl {level} {mob}!'
+    success: 'Successfully summoned a lvl {level} {mob}!'
 mobs:
   blaze: Blaze
   cave_spider: Cave Spider
@@ -41,4 +46,4 @@ mobs:
   wither: Wither
   elder_guardian: Elder Guardian
   creaking: Creaking
-file_version: 2
+file_version: 3

--- a/src/main/resources/messages/messages_es.yml
+++ b/src/main/resources/messages/messages_es.yml
@@ -1,5 +1,10 @@
 commands:
   reload: '¡AuraMobs recargado exitosamente!'
+  summon:
+    console: '¡Este subcomando solo puede ser ejecutado por jugadores!'
+    invalid: 'Tipo de mob no válido: {type}'
+    failure: '¡No se pudo invocar a un {mob} de nivel {level}!'
+    success: '¡{mob} de nivel {level} invocado con éxito!'
 mobs:
   blaze: Blaze
   cave_spider: Araña de Cueva
@@ -40,4 +45,4 @@ mobs:
   ender_dragon: Enderdragón
   wither: Wither
   elder_guardian: Guardián anciano
-file_version: 1
+file_version: 2

--- a/src/main/resources/messages/messages_nl.yml
+++ b/src/main/resources/messages/messages_nl.yml
@@ -1,5 +1,10 @@
 commands:
   reload: 'AuraMobs succesvol opnieuw geladen!'
+  summon:
+    console: 'Deze subopdracht kan alleen door spelers worden uitgevoerd!'
+    invalid: 'Ongeldig mobtype: {type}'
+    failure: 'Kon geen lvl {level} {mob} oproepen!'
+    success: 'Succesvol een lvl {level} {mob} opgeroepen!'
 mobs:
   blaze: Blaze
   cave_spider: Grottenspin
@@ -40,4 +45,4 @@ mobs:
   ender_dragon: Enderdraak
   wither: Wither
   elder_guardian: Oude bewaker
-file_version: 1
+file_version: 2


### PR DESCRIPTION
- **Added** a new subcommand to summon scaled mobs (`/auramobs summon <type> <level>`)
- **Added** accurate damage scaling for damage from creeper explosions and arrows (skeletons)
- **Added** damage multipliers for those two damage sources to mob_defaults.damage, to be able to, for example, buff arrows to actually deal significant damage and/or slightly nerf creeper explosions to not get instantly obliterated by them
- **Added** a speed property that allows scaling a mobs movement speed with its level (I've added a reasonable formula as default value, but just imagine a creeper sprinting towards you at 200mph)
- **Added** some useful custom exp4j functions that, among other things, allow adding randomness to expressions:
   - **random_between(min, max)** » Returns a random number between min and max
   - **rand()** » Returns a random float between 0 and 1
   - **clamp(value, min, max)** » Clamps a value between a minimum and maximum
   - **lerp(a, b, t)** » Performs linear interpolation between a and b using t (0.0 to 1.0)
   - **logn(base, value)** » Computes the logarithm of a value with a custom base
   - **round(x)** » Rounds a value to the nearest whole number